### PR TITLE
Fix misaligned memory access

### DIFF
--- a/llmnr.c
+++ b/llmnr.c
@@ -124,8 +124,10 @@ static void llmnr_respond(unsigned int ifindex, const struct llmnr_hdr *hdr,
 	if ((query_len - name_len - 2) < (sizeof(qtype) + sizeof(qclass)))
 		return;
 
-	qtype = ntohs(*((uint16_t *)query_name_end));
-	qclass = ntohs(*((uint16_t *)query_name_end + 1));
+	memcpy(&qtype, query_name_end, 2);
+	qtype = ntohs(qtype);
+	memcpy(&qclass, query_name_end + 2, 2);
+	qclass = ntohs(qclass);
 
 	/* Only IN queries supported */
 	if (qclass != LLMNR_QCLASS_IN)

--- a/pkt.h
+++ b/pkt.h
@@ -100,8 +100,8 @@ static inline uint8_t *pkt_put(struct pkt *p, size_t len)
 #define DEFINE_PKT_PUT(__bitwidth)							\
 static inline void pkt_put_u##__bitwidth(struct pkt *p, uint##__bitwidth##_t val)	\
 {											\
-	uint##__bitwidth##_t *data = (uint##__bitwidth##_t *)pkt_put(p, sizeof(val));	\
-	*data = val;									\
+	uint8_t *data = pkt_put(p, sizeof(val));	\
+	memcpy(data, &val, sizeof(uint##__bitwidth##_t));	\
 }
 
 DEFINE_PKT_PUT(8)


### PR DESCRIPTION
This changes fixes misaligned memory access. Without the patch I get several "Misaligend access trap for user program 'llmnrd'" messages on my platform if the system has odd hostname length.
