### PR TITLE
Makefile: assign CC conditionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ Q_OBJS	= util.o llmnr-query.o
 Q_LIBS	=
 Q_MAN	= $(Q_P).1
 
-CC	= $(CROSS_COMPILE)gcc
+CC	?= $(CROSS_COMPILE)gcc
 INSTALL	= install
 GZIP	= gzip -9 -c
 


### PR DESCRIPTION
Hi,

first of all, my compliments. llmnrd looks to be a very nice, to the point tool. And does exactly what I was looking for.

See below commit, fixes an error like this:

```
$ make
  CC llmnr.c
llmnr.c:20:19: fatal error: ctype.h: No such file or directory
compilation terminated.
Makefile:81: recipe for target 'llmnr.o' failed
make: *** [llmnr.o] Error 1
```

In my env, CC is already defined, like this:
```
CC=arm-ve-linux-gnueabi-gcc  -march=armv7-a -mfloat-abi=hard -mfpu=neon -mtune=cortex-a8 --sysroot=/opt/venus/jethro-arm-cortexa8hf-neon/sysroots/cortexa8hf-vfp-neon-ve-linux-gnueabi
```

