### PR TITLE
adding functionality (query app run always and scan for all hosts)

### DIFF
--- a/llmnr-query.c
+++ b/llmnr-query.c
@@ -353,7 +353,8 @@ int main(int argc, char **argv)
 					
 					//add or not to hosts lists
 					flag = 0;
-					for(int k = 0; k < index; ++k){
+					int k;
+					for(k = 0; k < index; ++k){
 						if(strcmp(addr,addr_list[k].addr) == 0){
 							flag = 1;
 							

--- a/llmnr-query.c
+++ b/llmnr-query.c
@@ -357,8 +357,6 @@ int main(int argc, char **argv)
 					for(k = 0; k < index; ++k){
 						if(strcmp(addr,addr_list[k].addr) == 0){
 							flag = 1;
-							
-							//log_dbg("%s %s\n",addr,addr_list[i].addr);
 						}
 					}
 
@@ -372,7 +370,7 @@ int main(int argc, char **argv)
 						index++;
 						log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
 					}
-					//log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
+					
 				}
 			} else{
 				index = 0;

--- a/llmnr-query.c
+++ b/llmnr-query.c
@@ -73,7 +73,8 @@ static void __noreturn usage_and_exit(int status)
 			"  -6, --ipv6            send queries over IPv6\n"
 			"  -C, --conflict        set conflict bit in query\n"
 			"  -h, --help            show this help and exit\n"
-			"  -V, --version         show version information and exit\n");
+			"  -V, --version         show version information and exit\n"
+			" \"\" scan for all hosts also for meaningful scan use with -R option or -c with amount of packet\n");
 	exit(status);
 }
 
@@ -188,14 +189,12 @@ int main(int argc, char **argv)
 	
 	
 
-	p = pkt_alloc(LLMNR_QUERY_PKT_BUF_SIZE);
-	if(query_name[0] == '*' && query_name[1] == '*')
-		count = 65538; // MAX IP
 	log_info("LLMNR query: %s IN %s\n", query_name, query_type(qtype));
 
 	do{
 		if((sock = init_socket(ipv6,TTL,iface)) == -1)
 			goto err;
+		p = pkt_alloc(LLMNR_QUERY_PKT_BUF_SIZE);	
 		for (i = 0; i < count ; i++) {
 			struct llmnr_hdr *hdr;
 			struct sockaddr_storage sst;
@@ -384,10 +383,11 @@ int main(int argc, char **argv)
 				usleep(interval_ms * 1000);
 			}
 		}
+		pkt_free(p);
 		close(sock);
 	}while(runAlways);
 
-	pkt_free(p);
+	
 	log_info("Finished .. \n");
 err:
 	close(sock);

--- a/llmnr-query.c
+++ b/llmnr-query.c
@@ -86,6 +86,8 @@ static void __noreturn version_and_exit(void)
 	exit(EXIT_SUCCESS);
 }
 
+int init_socket(bool ipv6,int TTL,const char * iface);
+
 static const char *query_type(uint16_t qtype)
 {
 	switch (qtype) {
@@ -116,7 +118,7 @@ int main(int argc, char **argv)
 	uint16_t qtype = LLMNR_QTYPE_ANY;
 	bool ipv6 = false;
 	struct pkt *p;
-	unsigned int ifindex = 0;
+	
 	static const int TTL = 255;
 	struct addr_name_entry *addr_list;
 	int runAlways = 0;
@@ -183,7 +185,218 @@ int main(int argc, char **argv)
 		log_err("Query name too long\n");
 		return -1;
 	}
-again:
+	
+	
+
+	p = pkt_alloc(LLMNR_QUERY_PKT_BUF_SIZE);
+	if(query_name[0] == '*' && query_name[1] == '*')
+		count = 65538; // MAX IP
+	log_info("LLMNR query: %s IN %s\n", query_name, query_type(qtype));
+
+	do{
+		if((sock = init_socket(ipv6,TTL,iface)) == -1)
+			goto err;
+		for (i = 0; i < count ; i++) {
+			struct llmnr_hdr *hdr;
+			struct sockaddr_storage sst;
+			socklen_t sst_len;
+			struct iovec iov[1];
+			struct msghdr msg;
+			struct in6_pktinfo ipi6;
+			uint8_t c[CMSG_SPACE(sizeof(ipi6))];
+			size_t query_pkt_len;
+			fd_set rfds;
+			struct timeval tv;
+			int ret;
+
+			hdr = (struct llmnr_hdr *)pkt_put(p, sizeof(*hdr));
+			hdr->id = htons(id + i % UINT16_MAX);
+			hdr->flags = htons(flags);
+			hdr->qdcount = htons(1);
+			hdr->ancount = 0;
+			hdr->nscount = 0;
+			hdr->arcount = 0;
+
+			pkt_put_u8(p, (uint8_t)query_name_len);
+			memcpy(pkt_put(p, query_name_len), query_name, query_name_len);
+			pkt_put_u8(p, 0);
+
+			pkt_put_u16(p, htons(qtype));
+			pkt_put_u16(p, htons(LLMNR_QCLASS_IN));
+
+			memset(&sst, 0, sizeof(sst));
+			memset(&iov, 0, sizeof(iov));
+			memset(&msg, 0, sizeof(msg));
+			memset(&ipi6, 0, sizeof(ipi6));
+
+			if (ipv6) {
+				struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)&sst;
+				struct cmsghdr *cmsg;
+
+				sin6->sin6_family = AF_INET6;
+				sin6->sin6_port = htons(LLMNR_UDP_PORT);
+				if (inet_pton(AF_INET6, LLMNR_IPV6_MCAST_ADDR, &sin6->sin6_addr) != 1) {
+					log_err("Failed to convert IPv6 address: %s\n", strerror(errno));
+					break;
+				}
+				sst_len = sizeof(*sin6);
+
+				ipi6.ipi6_ifindex = if_nametoindex(iface);;
+				msg.msg_control = c;
+				msg.msg_controllen = sizeof(c);
+				cmsg = CMSG_FIRSTHDR(&msg);
+				cmsg->cmsg_level = IPPROTO_IPV6;
+				cmsg->cmsg_type = IPV6_PKTINFO;
+				cmsg->cmsg_len = CMSG_LEN(sizeof(ipi6));
+				memcpy(CMSG_DATA(cmsg), &ipi6, sizeof(ipi6));
+			} else {
+				struct sockaddr_in *sin = (struct sockaddr_in *)&sst;
+
+				sin->sin_family = AF_INET;
+				sin->sin_port = htons(LLMNR_UDP_PORT);
+				if (inet_pton(AF_INET, LLMNR_IPV4_MCAST_ADDR, &sin->sin_addr) != 1) {
+					log_err("Failed to convert IPv4 address: %s\n", strerror(errno));
+					break;
+				}
+				sst_len = sizeof(*sin);
+			}
+
+			iov[0].iov_base = p->data;
+			iov[0].iov_len = pkt_len(p);
+			msg.msg_iov = iov;
+			msg.msg_iovlen = 1;
+			msg.msg_name = &sst;
+			msg.msg_namelen = sst_len;
+
+			if (sendmsg(sock, &msg, 0) < 0) {
+				log_err("Failed to send UDP packet: %s\n", strerror(errno));
+				break;
+			}
+
+			FD_ZERO(&rfds);
+			FD_SET(sock, &rfds);
+
+			tv.tv_sec = timeout_ms / 1000;
+			tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+			ret = select(sock + 1, &rfds, NULL, NULL, &tv);
+			if (ret < 0) {
+				log_err("Failed to select() on socket: %s\n", strerror(errno));
+				break;
+			} else if (ret) {
+				uint16_t j, ancount;
+
+				/* save query length and re-use packet for RX */
+				query_pkt_len = pkt_len(p) - sizeof(*hdr);
+				pkt_reset(p);
+
+				if (recv(sock, p->data, p->size, 0) < 0) {
+					log_err("Failed to receive from socket: %s\n", strerror(errno));
+					break;
+				}
+
+				hdr = (struct llmnr_hdr *)pkt_put(p, sizeof(*hdr));
+				ancount = htons(hdr->ancount);
+
+				if (ancount == 0) {
+					log_info("LLMNR response: no answer records returned\n");
+					continue;
+				}
+
+				/* skip the original query */
+				pkt_put(p, query_pkt_len);
+
+				for (j = 0; j < ancount; ++j) {
+					uint8_t nl = pkt_put_extract_u8(p);
+					char addr[INET6_ADDRSTRLEN + 1];
+					uint16_t type, clss, addr_size;
+					uint32_t ttl;
+					char name[LLMNR_LABEL_MAX_SIZE + 1];
+					int af;
+
+					/* compression? */
+					if (nl & 0xC0) {
+						uint16_t ptr = (nl & 0x3F) << 8 | pkt_put_extract_u8(p);
+						if (ptr < p->size - 1) {
+							uint8_t nnl = p->data[ptr];
+							strncpy(name, (char *)&p->data[ptr + 1], nnl);
+							name[nnl] = '\0';
+						} else
+							strncpy(name, "<invalid>", LLMNR_LABEL_MAX_SIZE);
+					} else {
+						strncpy(name, (char *)pkt_put(p, nl + 1), nl);
+						name[nl] = '\0';
+					}
+
+					type = htons(pkt_put_extract_u16(p));
+					clss = htons(pkt_put_extract_u16(p));
+
+					if (clss != LLMNR_CLASS_IN)
+						break;					
+						//log_warn("Unexpected response class received: %d\n", clss);
+
+					ttl = htonl(pkt_put_extract_u32(p));
+					addr_size = htons(pkt_put_extract_u16(p));
+
+					if (addr_size == sizeof(struct in_addr)) {
+						af = AF_INET;
+					} else if (addr_size == sizeof(struct in6_addr)) {
+						af = AF_INET6;
+					} else {
+						//log_warn("Unexpected address size received: %d\n", addr_size);
+						break;
+					}
+
+					memcpy(&sst, pkt_put(p, addr_size), addr_size);
+					if (!inet_ntop(af, &sst, addr, ARRAY_SIZE(addr)))
+						strncpy(addr, "<invalid>", sizeof(addr));
+					addr[INET6_ADDRSTRLEN] = '\0';
+					
+					//add or not to hosts lists
+					flag = 0;
+					for(int k = 0; k < index; ++k){
+						if(strcmp(addr,addr_list[k].addr) == 0){
+							flag = 1;
+							
+							//log_dbg("%s %s\n",addr,addr_list[i].addr);
+						}
+					}
+
+					if(!flag){
+						if(index == size ){
+							size *= 2;
+							addr_list = xrealloc(addr_list,sizeof(struct addr_name_entry) * size);
+						}
+						sprintf(addr_list[index].addr,"%s",addr);
+						sprintf(addr_list[index].name,"%s",name);
+						index++;
+						log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
+					}
+					//log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
+				}
+			} else{
+				index = 0;
+				log_info("No LLMNR response received within timeout (%lu ms)\n", timeout_ms);
+				continue;
+			}
+			if (i < count - 1) {
+				pkt_reset(p);
+				usleep(interval_ms * 1000);
+			}
+		}
+		close(sock);
+	}while(runAlways);
+
+	pkt_free(p);
+	log_info("Finished .. \n");
+err:
+	close(sock);
+	
+	return 0;
+}
+
+int init_socket(bool ipv6,int TTL,const char * iface){
+	int sock,ifindex;
 	sock = socket(ipv6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0);
 	if (sock < 0) {
 		log_err("Failed to open UDP socket: %s\n", strerror(errno));
@@ -194,23 +407,23 @@ again:
 		/* RFC 4795, section 2.5 recommends to set TTL to 255 for UDP */
 		if (setsockopt(sock, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &TTL, sizeof(TTL)) < 0) {
 			log_err("Failed to set IPv6 unicast hops socket option: %s\n", strerror(errno));
-			goto err;
+			return -1;
 		}
 
 		if (setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &TTL, sizeof(TTL)) < 0) {
 			log_err("Failed to set IPv6 multicast hops socket option: %s\n", strerror(errno));
-			goto err;
+			return -1;
 		}
 	} else {
 		/* RFC 4795, section 2.5 recommends to set TTL to 255 for UDP */
 		if (setsockopt(sock, IPPROTO_IP, IP_TTL, &TTL, sizeof(TTL)) < 0) {
 			log_err("Failed to set IPv4 unicast TTL socket option: %s\n", strerror(errno));
-			goto err;
+			return -1;
 		}
 
 		if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_TTL, &TTL, sizeof(TTL)) < 0) {
 			log_err("Failed to set IPv4 multicast TTL socket option: %s\n", strerror(errno));
-			goto err;
+			return -1;
 		}
 	}
 
@@ -219,14 +432,14 @@ again:
 
 		if (ifindex == 0 && errno != 0) {
 			log_err("Could not get interface %s: %s\n", iface, strerror(errno));
-			goto err;
+			return -1;
 		}
 
 		if (ipv6) {
 			if (setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) < 0) {
 				log_err("Failed to set interface '%s' for IPv6 multicast socket: %s\n",
 					iface, strerror(errno));
-				goto err;
+				return -1;
 			}
 		} else {
 			struct ip_mreqn mreq;
@@ -237,217 +450,10 @@ again:
 			if (setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, &mreq, sizeof(mreq)) < 0) {
 				log_err("Failed to set interface '%s' for IPv4 multicast socket: %s\n",
 					iface, strerror(errno));
-				goto err;
+				return -1;
 			}
 		}
 	}
 
-	p = pkt_alloc(LLMNR_QUERY_PKT_BUF_SIZE);
-	if(query_name[0] == '*' && query_name[1] == '*')
-		;//count = 65538; // just for Test
-	if(runAlways <= 1)
-		log_info("LLMNR query: %s IN %s\n", query_name, query_type(qtype));
-
-	
-	for (i = 0; i < count ; i++) {
-		struct llmnr_hdr *hdr;
-		struct sockaddr_storage sst;
-		socklen_t sst_len;
-		struct iovec iov[1];
-		struct msghdr msg;
-		struct in6_pktinfo ipi6;
-		uint8_t c[CMSG_SPACE(sizeof(ipi6))];
-		size_t query_pkt_len;
-		fd_set rfds;
-		struct timeval tv;
-		int ret;
-
-		hdr = (struct llmnr_hdr *)pkt_put(p, sizeof(*hdr));
-		hdr->id = htons(id + i % UINT16_MAX);
-		hdr->flags = htons(flags);
-		hdr->qdcount = htons(1);
-		hdr->ancount = 0;
-		hdr->nscount = 0;
-		hdr->arcount = 0;
-
-		pkt_put_u8(p, (uint8_t)query_name_len);
-		memcpy(pkt_put(p, query_name_len), query_name, query_name_len);
-		pkt_put_u8(p, 0);
-
-		pkt_put_u16(p, htons(qtype));
-		pkt_put_u16(p, htons(LLMNR_QCLASS_IN));
-
-		memset(&sst, 0, sizeof(sst));
-		memset(&iov, 0, sizeof(iov));
-		memset(&msg, 0, sizeof(msg));
-		memset(&ipi6, 0, sizeof(ipi6));
-
-		if (ipv6) {
-			struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)&sst;
-			struct cmsghdr *cmsg;
-
-			sin6->sin6_family = AF_INET6;
-			sin6->sin6_port = htons(LLMNR_UDP_PORT);
-			if (inet_pton(AF_INET6, LLMNR_IPV6_MCAST_ADDR, &sin6->sin6_addr) != 1) {
-				log_err("Failed to convert IPv6 address: %s\n", strerror(errno));
-				break;
-			}
-			sst_len = sizeof(*sin6);
-
-			ipi6.ipi6_ifindex = ifindex;
-			msg.msg_control = c;
-			msg.msg_controllen = sizeof(c);
-			cmsg = CMSG_FIRSTHDR(&msg);
-			cmsg->cmsg_level = IPPROTO_IPV6;
-			cmsg->cmsg_type = IPV6_PKTINFO;
-			cmsg->cmsg_len = CMSG_LEN(sizeof(ipi6));
-			memcpy(CMSG_DATA(cmsg), &ipi6, sizeof(ipi6));
-		} else {
-			struct sockaddr_in *sin = (struct sockaddr_in *)&sst;
-
-			sin->sin_family = AF_INET;
-			sin->sin_port = htons(LLMNR_UDP_PORT);
-			if (inet_pton(AF_INET, LLMNR_IPV4_MCAST_ADDR, &sin->sin_addr) != 1) {
-				log_err("Failed to convert IPv4 address: %s\n", strerror(errno));
-				break;
-			}
-			sst_len = sizeof(*sin);
-		}
-
-		iov[0].iov_base = p->data;
-		iov[0].iov_len = pkt_len(p);
-		msg.msg_iov = iov;
-		msg.msg_iovlen = 1;
-		msg.msg_name = &sst;
-		msg.msg_namelen = sst_len;
-
-		if (sendmsg(sock, &msg, 0) < 0) {
-			log_err("Failed to send UDP packet: %s\n", strerror(errno));
-			break;
-		}
-
-		FD_ZERO(&rfds);
-		FD_SET(sock, &rfds);
-
-		tv.tv_sec = timeout_ms / 1000;
-		tv.tv_usec = (timeout_ms % 1000) * 1000;
-
-		ret = select(sock + 1, &rfds, NULL, NULL, &tv);
-		if (ret < 0) {
-			log_err("Failed to select() on socket: %s\n", strerror(errno));
-			break;
-		} else if (ret) {
-			uint16_t j, ancount;
-
-			/* save query length and re-use packet for RX */
-			query_pkt_len = pkt_len(p) - sizeof(*hdr);
-			pkt_reset(p);
-
-			if (recv(sock, p->data, p->size, 0) < 0) {
-				log_err("Failed to receive from socket: %s\n", strerror(errno));
-				break;
-			}
-
-			hdr = (struct llmnr_hdr *)pkt_put(p, sizeof(*hdr));
-			ancount = htons(hdr->ancount);
-
-			if (ancount == 0) {
-				log_info("LLMNR response: no answer records returned\n");
-				continue;
-			}
-
-			/* skip the original query */
-			pkt_put(p, query_pkt_len);
-
-			for (j = 0; j < ancount; ++j) {
-				uint8_t nl = pkt_put_extract_u8(p);
-				char addr[INET6_ADDRSTRLEN + 1];
-				uint16_t type, clss, addr_size;
-				uint32_t ttl;
-				char name[LLMNR_LABEL_MAX_SIZE + 1];
-				int af;
-
-				/* compression? */
-				if (nl & 0xC0) {
-					uint16_t ptr = (nl & 0x3F) << 8 | pkt_put_extract_u8(p);
-					if (ptr < p->size - 1) {
-						uint8_t nnl = p->data[ptr];
-						strncpy(name, (char *)&p->data[ptr + 1], nnl);
-						name[nnl] = '\0';
-					} else
-						strncpy(name, "<invalid>", LLMNR_LABEL_MAX_SIZE);
-				} else {
-					strncpy(name, (char *)pkt_put(p, nl + 1), nl);
-					name[nl] = '\0';
-				}
-
-				type = htons(pkt_put_extract_u16(p));
-				clss = htons(pkt_put_extract_u16(p));
-
-				if (clss != LLMNR_CLASS_IN)
-					break;					
-					//log_warn("Unexpected response class received: %d\n", clss);
-
-				ttl = htonl(pkt_put_extract_u32(p));
-				addr_size = htons(pkt_put_extract_u16(p));
-
-				if (addr_size == sizeof(struct in_addr)) {
-					af = AF_INET;
-				} else if (addr_size == sizeof(struct in6_addr)) {
-					af = AF_INET6;
-				} else {
-					//log_warn("Unexpected address size received: %d\n", addr_size);
-					break;
-				}
-
-				memcpy(&sst, pkt_put(p, addr_size), addr_size);
-				if (!inet_ntop(af, &sst, addr, ARRAY_SIZE(addr)))
-					strncpy(addr, "<invalid>", sizeof(addr));
-				addr[INET6_ADDRSTRLEN] = '\0';
-				
-				//add or not to hosts lists
-				flag = 0;
-				for(int k = 0; k < index; ++k){
-					if(strcmp(addr,addr_list[k].addr) == 0){
-						flag = 1;
-						
-						//log_dbg("%s %s\n",addr,addr_list[i].addr);
-					}
-				}
-
-				if(!flag){
-					if(index == size ){
-						size *= 2;
-						addr_list = xrealloc(addr_list,sizeof(struct addr_name_entry) * size);
-					}
-					sprintf(addr_list[index].addr,"%s",addr);
-					sprintf(addr_list[index].name,"%s",name);
-					index++;
-					log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
-				}
-				//log_info("LLMNR response: %s IN %s %s (TTL %d)\n", name, query_type(type), addr, ttl);
-			}
-		} else{
-			index = 0;
-			log_info("No LLMNR response received within timeout (%lu ms)\n", timeout_ms);
-			continue;
-		}
-		if (i < count - 1) {
-			pkt_reset(p);
-			usleep(interval_ms * 1000);
-		}
-	}
-
-	pkt_free(p);
-err:
-	close(sock);
-
-	if(runAlways)
-	{
-		log_dbg("Rescaning ...\n");
-		runAlways++;
-		goto again;
-	}
-	log_info("Finished .. \n");
-	return 0;
+	return sock;
 }

--- a/llmnr.c
+++ b/llmnr.c
@@ -61,7 +61,7 @@ static bool llmnr_name_matches(const uint8_t *query)
 	uint8_t n = llmnr_hostname[0];
 	
 	/*if requested ** that means response me everybody */
-	if(((const char *)&query[1])[0] == '*' && ((const char *)&query[1])[1] == '*' ){
+	if(((const char *)&query[1])[0] == '*' && 1 == query[0] ){
 		return true;
 	}
 	

--- a/llmnr.c
+++ b/llmnr.c
@@ -38,7 +38,6 @@
 #include "llmnr-packet.h"
 #include "llmnr.h"
 
-// #define RESPOND_ALL 1
 
 static bool llmnr_ipv6 = false;
 /* Host name in DNS name format (length octet + name + 0 byte) */
@@ -225,7 +224,7 @@ static void llmnr_packet_process(unsigned int ifindex, const uint8_t *pktbuf, si
 		return;
 
 	/* Authoritative? */
-	if (llmnr_name_matches(query) /*|| RESPOND_ALL*/)
+	if (llmnr_name_matches(query))
 		llmnr_respond(ifindex, hdr, query, query_len, sock, sst);
 }
 

--- a/llmnr.c
+++ b/llmnr.c
@@ -38,6 +38,8 @@
 #include "llmnr-packet.h"
 #include "llmnr.h"
 
+// #define RESPOND_ALL 1
+
 static bool llmnr_ipv6 = false;
 /* Host name in DNS name format (length octet + name + 0 byte) */
 static char llmnr_hostname[LLMNR_LABEL_MAX_SIZE + 2];
@@ -66,7 +68,8 @@ static bool llmnr_name_matches(const uint8_t *query)
 	if (query[1 + n] != 0)
 		return false;
 
-	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0;
+	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0 || ((const char *)&query[1][0] == '*' && 
+																				(const char *)&query[1][1] == '*' );
 }
 
 static void llmnr_respond(unsigned int ifindex, const struct llmnr_hdr *hdr,
@@ -218,7 +221,7 @@ static void llmnr_packet_process(unsigned int ifindex, const uint8_t *pktbuf, si
 		return;
 
 	/* Authoritative? */
-	if (llmnr_name_matches(query))
+	if (llmnr_name_matches(query) /*|| RESPOND_ALL*/)
 		llmnr_respond(ifindex, hdr, query, query_len, sock, sst);
 }
 

--- a/llmnr.c
+++ b/llmnr.c
@@ -60,16 +60,20 @@ void llmnr_init(const char *hostname, bool ipv6)
 static bool llmnr_name_matches(const uint8_t *query)
 {
 	uint8_t n = llmnr_hostname[0];
-
+	
+	/*if requested ** that means response me everybody */
+	if(((const char *)&query[1])[0] == '*' && ((const char *)&query[1])[1] == '*' ){
+		return true;
+	}
+	
 	/* length */
 	if (query[0] != n)
 		return false;
 	/* NULL byte */
 	if (query[1 + n] != 0)
 		return false;
-
-	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0 || (((const char *)&query[1])[0] == '*' && 
-																				((const char *)&query[1])[1] == '*' );
+	
+	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0 ;
 }
 
 static void llmnr_respond(unsigned int ifindex, const struct llmnr_hdr *hdr,

--- a/llmnr.c
+++ b/llmnr.c
@@ -68,8 +68,8 @@ static bool llmnr_name_matches(const uint8_t *query)
 	if (query[1 + n] != 0)
 		return false;
 
-	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0 || ((const char *)&query[1][0] == '*' && 
-																				(const char *)&query[1][1] == '*' );
+	return strncasecmp((const char *)&query[1], &llmnr_hostname[1], n) == 0 || (((const char *)&query[1])[0] == '*' && 
+																				((const char *)&query[1])[1] == '*' );
 }
 
 static void llmnr_respond(unsigned int ifindex, const struct llmnr_hdr *hdr,


### PR DESCRIPTION
Hello, I add some functionality but I don't know it fits RFC document. It is very useful to me so I want to publish. 
I add 2 functionality : 
-  Scan all network by typing "**" to **NAME** option in llmnr-query app. 
- llmnr-query app can always run now. With that solution, we can see any changes when happened. (-R option)
