### PR TITLE
llmnrd: set stdout to line buffering

### DIFF
--- a/llmnrd.c
+++ b/llmnrd.c
@@ -161,6 +161,8 @@ int main(int argc, char **argv)
 	int llmnrd_sock_rtnl = -1;
 	int nfds;
 
+	setlinebuf(stdout);
+
 	while ((c = getopt_long(argc, argv, short_opts, long_opts, NULL)) != -1) {
 		switch (c) {
 		case 'd':


### PR DESCRIPTION
See commit msg. Thanks again for the great project. And if you know a way to get zeroconf name resolution on Android / Chrome, I'll be grateful. I found it to not work, not with llmnr, and not with mDNS:

https://bugs.chromium.org/p/chromium/issues/detail?id=405925&desc=2