### PR TITLE
llmnrd: add command line option to log to syslog instead of stdio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ VERSION = 0.6
 
 # llmnrd binary
 D_P 	= llmnrd
-D_OBJS	= llmnr.o iface.o socket.o util.o llmnrd.o
+D_OBJS	= llmnr.o iface.o socket.o util.o log.o llmnrd.o
 D_LIBS	=
 D_MAN	= $(D_P).8
 
 # llmnr-query binary
 Q_P 	= llmnr-query
-Q_OBJS	= util.o llmnr-query.o
+Q_OBJS	= util.o log.o llmnr-query.o
 Q_LIBS	=
 Q_MAN	= $(Q_P).1
 

--- a/llmnrd.c
+++ b/llmnrd.c
@@ -49,13 +49,14 @@ static int llmnrd_sock_ipv4 = -1;
 static int llmnrd_sock_ipv6 = -1;
 static int llmnrd_fd_hostname = -1;
 
-static const char *short_opts = "H:i:p:6dhV";
+static const char *short_opts = "H:i:p:6dshV";
 static const struct option long_opts[] = {
 	{ "hostname",	required_argument,	NULL, 'H' },
 	{ "interface",  required_argument,	NULL, 'i' },
 	{ "port",	required_argument,	NULL, 'p' },
 	{ "ipv6",	no_argument,		NULL, '6' },
 	{ "daemonize",	no_argument,		NULL, 'd' },
+	{ "syslog",	no_argument,		NULL, 's' },
 	{ "help",	no_argument,		NULL, 'h' },
 	{ "version",	no_argument,		NULL, 'V' },
 	{ NULL,		0,			NULL, 0 },
@@ -70,6 +71,7 @@ static void __noreturn usage_and_exit(int status)
 			"  -p, --port NUM       set port number to listen on (default: %d)\n"
 			"  -6, --ipv6           enable LLMNR name resolution over IPv6\n"
 			"  -d, --daemonize      run as daemon in the background\n"
+			"  -s, --syslog         send all log output to syslog\n"
 			"  -h, --help           show this help and exit\n"
 			"  -V, --version        show version information and exit\n",
 			LLMNR_UDP_PORT);
@@ -167,6 +169,10 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 'd':
 			daemonize = true;
+			break;
+		case 's':
+			openlog("llmnrd", LOG_PID, LOG_DAEMON);
+			log_to_syslog();
 			break;
 		case 'H':
 			hostname = xstrdup(optarg);

--- a/log.c
+++ b/log.c
@@ -1,0 +1,39 @@
+#include <stdarg.h>
+#include <stdbool.h>
+
+#include "log.h"
+
+static bool use_syslog;
+
+void log_lvl(int lvl, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+
+	if (!use_syslog) {
+		FILE *out = stderr;
+		switch (lvl) {
+		case LOG_ERR:
+			fputs("Error: ", stderr);
+			break;
+		case LOG_WARNING:
+			fputs("Warning: ", stderr);
+			break;
+		case LOG_INFO:
+		case LOG_DEBUG:
+			out = stdout;
+			break;
+		}
+		vfprintf(out, fmt, ap);
+	} else {
+		vsyslog(lvl, fmt, ap);
+	}
+
+	va_end(ap);
+}
+
+void log_to_syslog(void)
+{
+	use_syslog = true;
+}

--- a/log.h
+++ b/log.h
@@ -20,12 +20,19 @@
 #define LOG_H
 
 #include <stdio.h>
+#include <syslog.h>
 
-#define log_err(fmt, args...)	fprintf(stderr, "Error: " fmt, ##args)
-#define log_warn(fmt, args...)	fprintf(stderr, "Warning: " fmt, ##args)
-#define log_info(fmt, args...)	fprintf(stdout, fmt, ##args)
+#include "compiler.h"
+
+void log_lvl(int lvl, const char *fmt, ...) __check_format_printf(2, 3);
+
+void log_to_syslog(void);
+
+#define log_err(fmt, args...)	log_lvl(LOG_ERR, fmt, ##args)
+#define log_warn(fmt, args...)	log_lvl(LOG_WARNING, fmt, ##args)
+#define log_info(fmt, args...)	log_lvl(LOG_INFO, fmt, ##args)
 #ifdef DEBUG
-# define log_dbg(fmt, args...)	fprintf(stdout, fmt, ##args)
+# define log_dbg(fmt, args...)	log_lvl(LOG_DEBUG, fmt, ##args)
 #else
 # define log_dbg(fmt, args...)
 #endif


### PR DESCRIPTION
When llmnrd daemonizes stdout and stderr are redirected to /dev/null
and all logs are lost. This adds a cli option -s / --syslog to send
the logs to syslog instead.

Signed-off-by: Diego Santa Cruz <Diego.SantaCruz@spinetix.com>