### PR TITLE
llmnrd: only async signal safe functions may be called in signal handler

### DIFF
--- a/llmnrd.c
+++ b/llmnrd.c
@@ -91,7 +91,6 @@ static void signal_handler(int sig)
 	case SIGINT:
 	case SIGQUIT:
 	case SIGTERM:
-		log_info("Interrupt received. Stopping llmnrd.\n");
 		llmnrd_running = false;
 		break;
 	case SIGHUP:
@@ -280,6 +279,8 @@ int main(int argc, char **argv)
 				hostname_change_handle(hostname, MAXHOSTNAMELEN);
 		}
 	}
+
+	log_info("Signal received. Stopping llmnrd.\n");
 
 	ret = 0;
 out:


### PR DESCRIPTION
Signal handlers may only call async signal safe functions and logging
is certainly not async signal safe, so move the log message to the
main loop.

While at it change "Interrupt" for "Signal" in the message which is
more appropriate.

Signed-off-by: Diego Santa Cruz <Diego.SantaCruz@spinetix.com>