### PR TITLE
llmnrd: exit gracefully on select() EINTR

### DIFF
--- a/llmnrd.c
+++ b/llmnrd.c
@@ -262,9 +262,10 @@ int main(int argc, char **argv)
 
 		ret = select(nfds, &rfds, NULL, &efds, NULL);
 		if (ret < 0) {
-			if (errno != EINTR)
+			if (errno != EINTR) {
 				log_err("Failed to select() on socket: %s\n", strerror(errno));
-			goto out;
+				goto out;
+			}
 		} else if (ret) {
 			/* handle RTNL messages first so we can respond with
 			 * up-to-date information.


### PR DESCRIPTION
If a signal was caught, select returns with errno set to EINTR. The
signal handler already set llmnrd_running = false.

This will also make sure the log message moved by commit a1a821814101
("llmnrd: only async signal safe functions may be called in signal
handler") will get logged correctly in all cases and the process will
exit gracefully.