### PR TITLE
Allow to provide multiple host names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ enable LLMNR name resolution over IPv6 use:
 $ llmnrd -6
 ```
 
+By default, `llmnrd` respond to name requests matching the systems hostname.
+Provide one or more additional names via the `-H` argument:
+
+```
+$ llmnrd -H a_name -H another_name
+```
+
 Use `llmnrd --help` to show additional usage information.
 
 Additionally, the `llmnr-query` utility is shipped together with llmnrd and

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ enable LLMNR name resolution over IPv6 use:
 $ llmnrd -6
 ```
 
-By default, `llmnrd` respond to name requests matching the systems hostname.
-Provide one or more additional names via the `-H` argument:
+By default, `llmnrd` responds to name requests matching the systems hostname.
+Instead you can provide one or more names via the `-H` argument:
 
 ```
 $ llmnrd -H a_name -H another_name

--- a/llmnr.h
+++ b/llmnr.h
@@ -22,7 +22,8 @@
 #include <stdbool.h>
 
 void llmnr_set_hostname(const char *hostname);
-void llmnr_init(const char *hostname, bool ipv6);
+void llmnr_init(const char *hostnames[], int hostname_count, bool ipv6);
+void llmnr_release(void);
 void llmnr_recv(int sock);
 
 #endif /* LLMNR_H */

--- a/llmnr.h
+++ b/llmnr.h
@@ -22,7 +22,7 @@
 #include <stdbool.h>
 
 void llmnr_set_hostname(const char *hostname);
-void llmnr_init(const char *hostnames[], int hostname_count, bool ipv6);
+void llmnr_init(const char *hostnames[], size_t hostname_count, bool ipv6);
 void llmnr_release(void);
 void llmnr_recv(int sock);
 

--- a/llmnrd.c
+++ b/llmnrd.c
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
 	long num_arg;
 	bool daemonize = false, ipv6 = false;
 	char **hostnames = NULL;
-	int name_count = 0, name_i = 0;
+	size_t name_count = 0, name_i = 0;
 	char *iface = NULL;
 	uint16_t port = LLMNR_UDP_PORT;
 	int llmnrd_sock_rtnl = -1;
@@ -270,10 +270,10 @@ int main(int argc, char **argv)
 		rm_pid_file = true;
 	}
 
-	log_info("Starting llmnrd on port %u, hostname(s): ", port);
-    for(name_i = 0; name_i < name_count; ++name_i)
-        log_info("%s ", hostnames[name_i]);
-    log_info("\n");
+	log_info("Starting llmnrd on port %u. Assigned hostname(s):\n", port);
+
+	for(name_i = 0; name_i < name_count; ++name_i)
+		log_info("%s\n", hostnames[name_i]);
 
 	if (iface)
 		log_info("Binding to interface %s\n", iface);


### PR DESCRIPTION
Allow to provide multiple host names

* Readme amended
* Dynamic array of host name strings; Requires addition of `void llmnr_release(void);` method for string array cleanup
* Keep `llmnr_set_hostname` function signature. This will always only update the first entry.
* Adapt `llmnr_init` to take an array of host name strings.

Fixes #38